### PR TITLE
Fix host dialogue opacity logic

### DIFF
--- a/src/components/Hosts/HostDialogue.jsx
+++ b/src/components/Hosts/HostDialogue.jsx
@@ -7,8 +7,8 @@ export default function HostDialogue() {
     <div>
       <div style={{ fontWeight: 700, marginBottom: 6 }}>Pat</div>
       <div className="host-bubble" aria-live="polite">
-        {hostLines.slice(-3).map((l, i) => (
-          <div key={i} style={{ opacity: i < hostLines.length - 1 ? 0.7 : 1 }}>{l}</div>
+        {hostLines.slice(-3).map((l, i, arr) => (
+          <div key={i} style={{ opacity: i < arr.length - 1 ? 0.7 : 1 }}>{l}</div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Fix host dialogue opacity to highlight the most recent line correctly

## Testing
- `npm run test:e2e` *(fails: analyze, capture, e2e, smoke)*

------
https://chatgpt.com/codex/tasks/task_e_689ac1c6cf98832fa605443cd640e2f1